### PR TITLE
Optional gcloud authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,37 @@ deploy:
           command: create -f cities-controller.json
 ```
 
+# Google Container Engine (GKE) clusters
+
+Passing the contents of a Google service account private key JSON file in optional parameter `gcloud-key-json` will
+cause this step to use the gcloud SDK to authenticate kubectl for access to GKE with a Google service account.
+
+You'll also need to pass:
+
+```
+  gcloud-key-json:
+    type: string
+    required: false
+  gke-cluster-name:
+    type: string
+    required: false
+  gke-cluster-zone:
+    type: string
+    required: false
+  gke-cluster-project:
+    type: string
+    required: false
+```
+
 # License
 
 The MIT License (MIT)
 
 # Changelog
+
+## 3.1.8
+
+- Add support for authenticating kubectl with GKE clusters with a Google service account.
 
 ## 3.0.0
 

--- a/ewok.yml
+++ b/ewok.yml
@@ -11,15 +11,19 @@ build:
         - script:
             name: config
             code: |
+                GCLOUD_VERSION="127.0.0-linux-x86_64"
+                export GCLOUD_DIRNAME="google-cloud-sdk"
                 export KUBERNETES_VERSION="1.3.4"
                 export KUBERNETES_SHA256="81f0e3c788241419be1ee961da8804fdb16657b86e7edba8c7070932e8a50fe7"
-                echo "Installing version $KUBERNETES_VERSION of kubernetes"
+                export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
+                export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
+                export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
+                echo "Installing version $KUBERNETES_VERSION of kubernetes and ${GCLOUD_VERSION} of the Google Cloud SDK"
 
         - script:
             name: fetch kubernetes archive
             code: |
                 curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl > $WERCKER_OUTPUT_DIR/kubectl
-
 
         - script:
             name: validate kubernetes archive
@@ -27,9 +31,35 @@ build:
                 cat $WERCKER_OUTPUT_DIR/kubectl| sha256sum | grep -q "$KUBERNETES_SHA256"
 
         - script:
+            name: Fetch gcloud archive
+            code: |
+                curl -L ${GCLOUD_URL} -o ${GCLOUD_FILENAME}
+
+        - script:
+            name: Validate gcloud archive
+            code: |
+                sha1sum ${GCLOUD_FILENAME} | grep -q "${GCLOUD_SHA}"
+
+        - script:
+            name: Extract gcloud archive
+            code: |
+                tar -xzf ${GCLOUD_FILENAME}
+
+        - script:
+            name: Install kubectl gcloud component
+            code: |
+                yes | ${GCLOUD_DIRNAME}/bin/gcloud components install kubectl
+
+        - script:
+            name: Copy gcloud to output dir
+            code: |
+                cp -r "${GCLOUD_DIRNAME}" ${WERCKER_OUTPUT_DIR}
+
+        - script:
             name: prepare output
             code: |
-                cp "$WERCKER_ROOT/LICENSE" "$WERCKER_ROOT/README.md" "$WERCKER_ROOT/run.sh" "$WERCKER_ROOT/wercker.yml" "$WERCKER_ROOT/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"
 
 test-busybox:

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,9 +1,10 @@
 name: kubectl
-version: 3.0.0
-description: Step to run kubectl
+version: 3.1.8
+description: Step to run kubectl, with support for GKE clusters.
 keywords:
   - kubernetes
   - kubectl
+  - gke
 properties:
   token:
     type: string
@@ -90,6 +91,18 @@ properties:
     type: string
     required: false
   overwrite:
+    type: string
+    required: false
+  gcloud-key-json:
+    type: string
+    required: false
+  gke-cluster-name:
+    type: string
+    required: false
+  gke-cluster-zone:
+    type: string
+    required: false
+  gke-cluster-project:
     type: string
     required: false
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -6,9 +6,14 @@ build:
         - script:
             name: config
             code: |
+                GCLOUD_VERSION="127.0.0-linux-x86_64"
+                export GCLOUD_DIRNAME="google-cloud-sdk"
                 export KUBERNETES_VERSION="1.3.4"
                 export KUBERNETES_SHA256="81f0e3c788241419be1ee961da8804fdb16657b86e7edba8c7070932e8a50fe7"
-                echo "Installing version $KUBERNETES_VERSION of kubernetes"
+                export GCLOUD_SHA="45abe78986b0ff9a147904aaf20d552fa4ad6f29"
+                export GCLOUD_FILENAME="${GCLOUD_DIRNAME}-${GCLOUD_VERSION}.tar.gz"
+                export GCLOUD_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}"
+                echo "Installing version $KUBERNETES_VERSION of kubernetes and ${GCLOUD_VERSION} of the Google Cloud SDK"
 
         - script:
             name: fetch kubernetes archive
@@ -21,7 +26,33 @@ build:
                 cat $WERCKER_OUTPUT_DIR/kubectl| sha256sum | grep -q "$KUBERNETES_SHA256"
 
         - script:
+            name: Fetch gcloud archive
+            code: |
+                curl -L ${GCLOUD_URL} -o ${GCLOUD_FILENAME}
+
+        - script:
+            name: Validate gcloud archive
+            code: |
+                sha1sum ${GCLOUD_FILENAME} | grep -q "${GCLOUD_SHA}"
+
+        - script:
+            name: Extract gcloud archive
+            code: |
+                tar -xzf ${GCLOUD_FILENAME}
+
+        - script:
+            name: Install kubectl gcloud component
+            code: |
+                yes | ${GCLOUD_DIRNAME}/bin/gcloud components install kubectl
+
+        - script:
+            name: Copy gcloud to output dir
+            code: |
+                cp -r "${GCLOUD_DIRNAME}" ${WERCKER_OUTPUT_DIR}
+
+        - script:
             name: prepare output
             code: |
-                cp "$WERCKER_ROOT/LICENSE" "$WERCKER_ROOT/README.md" "$WERCKER_ROOT/run.sh" "$WERCKER_ROOT/wercker.yml" "$WERCKER_ROOT/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                cp  "${WERCKER_ROOT}/LICENSE" "${WERCKER_ROOT}/README.md" "${WERCKER_ROOT}/run.sh" "${WERCKER_ROOT}/wercker.yml" "${WERCKER_ROOT}/wercker-step.yml" "$WERCKER_OUTPUT_DIR"
+                chmod ugo+rx "$WERCKER_OUTPUT_DIR/${GCLOUD_DIRNAME}/bin/gcloud"
                 chmod ugo+rx "$WERCKER_OUTPUT_DIR/kubectl"


### PR DESCRIPTION
A recent change to Kubectl/GKE now makes it default to using OAuth2 IAM authentication rather than client certificate authentication on GKE, as it was previously. 

This PR implements the ability to pass a Google service account JSON file as a string which will now cause the step to activate & authenticate a service account, then configure kubectl.

This PR should resolve #13, and the underlying issue/change is discussed at length in https://github.com/kubernetes/kubernetes/issues/30617.

I'd love to hear your thoughts on this PR since I'm in two minds about requesting it to be merged back to master. On the one hand it lets kubectl work with service accounts in a similar manner to the internal docker push steps, but on the other hand the wercker.yml build is heavier, and the step is no longer entirely independent of platform

Also, I bumped 8 patch versions during testing, but wasn't able to reset it after deleting my testing step. Admin assistance would be appreciated if this does get merged!

Cheers